### PR TITLE
fix for multi-segment indexes

### DIFF
--- a/src/main/java/com/senseidb/clue/commands/StoredFieldCommand.java
+++ b/src/main/java/com/senseidb/clue/commands/StoredFieldCommand.java
@@ -54,7 +54,7 @@ public class StoredFieldCommand extends ClueCommand {
       stored = true;
       
       int docID = doc - ctx.docBase;
-      if (docID >= 0) {
+      if (docID >= 0 && docID < atomicReader.maxDoc()) {
       
         Document storedData = atomicReader.document(docID, new HashSet<String>(Arrays.asList(field)));
         


### PR DESCRIPTION
When the index is splitted in more than one segment, the store command was not working fine for docID that didn't belong to the first segment. It has been added a check on maxDoc for each segment in the main loop, so that document(..) method is called only for the correct segment.
