### PR TITLE
Code quality fix - "public static" fields should be constant

### DIFF
--- a/src/main/java/com/senseidb/clue/api/RawBytesRefDisplay.java
+++ b/src/main/java/com/senseidb/clue/api/RawBytesRefDisplay.java
@@ -11,5 +11,5 @@ public class RawBytesRefDisplay extends BytesRefDisplay {
     return BytesRefPrinter.RawBytesPrinter;
   }
 
-  public static RawBytesRefDisplay INSTANCE = new RawBytesRefDisplay();
+  public static final RawBytesRefDisplay INSTANCE = new RawBytesRefDisplay();
 }

--- a/src/main/java/com/senseidb/clue/api/StringBytesRefDisplay.java
+++ b/src/main/java/com/senseidb/clue/api/StringBytesRefDisplay.java
@@ -11,6 +11,6 @@ public class StringBytesRefDisplay extends BytesRefDisplay {
     return BytesRefPrinter.UTFPrinter;
   }
   
-  public static StringBytesRefDisplay INSTANCE = new StringBytesRefDisplay();
+  public static final StringBytesRefDisplay INSTANCE = new StringBytesRefDisplay();
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed