### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/com/senseidb/clue/ClueApplication.java
+++ b/src/main/java/com/senseidb/clue/ClueApplication.java
@@ -28,6 +28,17 @@ public class ClueApplication {
     }
   }
   
+  public ClueApplication(String idxLocation, boolean interactiveMode) throws Exception{
+      dir = config.getDirBuilder().build(new URI(idxLocation));
+      if (!DirectoryReader.indexExists(dir)){
+        System.out.println("lucene index does not exist at: "+idxLocation);
+        System.exit(1);
+      }
+          
+      ctx = newContext(dir, config, interactiveMode);
+      helpCommand = ctx.getCommand(HelpCommand.CMD_NAME);
+    }
+  
   public ClueContext getContext() {
     return ctx;
   }
@@ -38,17 +49,6 @@ public class ClueApplication {
   
   public ClueContext newContext(Directory dir, ClueConfiguration config, boolean interactiveMode) throws Exception {
     return new ClueContext(dir, config, interactiveMode);
-  }
-  
-  public ClueApplication(String idxLocation, boolean interactiveMode) throws Exception{
-    dir = config.getDirBuilder().build(new URI(idxLocation));
-    if (!DirectoryReader.indexExists(dir)){
-      System.out.println("lucene index does not exist at: "+idxLocation);
-      System.exit(1);
-    }
-        
-    ctx = newContext(dir, config, interactiveMode);
-    helpCommand = ctx.getCommand(HelpCommand.CMD_NAME);
   }
   
   public void handleCommand(String cmdName, String[] args, PrintStream out){

--- a/src/main/java/com/senseidb/clue/ClueConfiguration.java
+++ b/src/main/java/com/senseidb/clue/ClueConfiguration.java
@@ -37,6 +37,29 @@ public class ClueConfiguration {
   
   private final Properties config;
   
+  private ClueConfiguration(Properties config) { 
+      this.config = config;
+      analyzerQuery = getInstance(config.getProperty(ANALYZER_QUERY_PARAM), 
+          new StandardAnalyzer());
+      dirBuilder = getInstance(config.getProperty(DIRECTORY_BUILDER_PARAM),
+          new DefaultDirectoryBuilder());
+      queryBuilder = getInstance(config.getProperty(QUERY_BUILDER_PARAM),
+          new DefaultQueryBuilder());
+      indexReaderFactory = getInstance(config.getProperty(INDEX_READER_FACTORY_PARAM),
+          new DefaultIndexReaderFactory());
+      termBytesRefDisplay = getInstance(config.getProperty(TERM_BYTESREF_DISPLAY),
+          StringBytesRefDisplay.INSTANCE);
+      payloadBytesRefDisplay = getInstance(config.getProperty(PAYLOAD_BYTESREF_DISPLAY),
+          RawBytesRefDisplay.INSTANCE);
+      
+      System.out.println("Analyzer: \t\t" + analyzerQuery.getClass());
+      System.out.println("Query Builder: \t\t" + queryBuilder.getClass());
+      System.out.println("Directory Builder: \t" + dirBuilder.getClass());
+      System.out.println("IndexReader Factory: \t" + indexReaderFactory.getClass());
+      System.out.println("Term Bytesref Display: \t" + termBytesRefDisplay.getClass());
+      System.out.println("Payload Bytesref Display: \t" + payloadBytesRefDisplay.getClass());
+    }
+  
   private static <T> T getInstance(String className, T defaultInstance) {
     try {
       if (className == null) {
@@ -52,29 +75,6 @@ public class ClueConfiguration {
   
   public Properties getProperties() {
     return config;
-  }
-
-  private ClueConfiguration(Properties config) { 
-    this.config = config;
-    analyzerQuery = getInstance(config.getProperty(ANALYZER_QUERY_PARAM), 
-        new StandardAnalyzer());
-    dirBuilder = getInstance(config.getProperty(DIRECTORY_BUILDER_PARAM),
-        new DefaultDirectoryBuilder());
-    queryBuilder = getInstance(config.getProperty(QUERY_BUILDER_PARAM),
-        new DefaultQueryBuilder());
-    indexReaderFactory = getInstance(config.getProperty(INDEX_READER_FACTORY_PARAM),
-        new DefaultIndexReaderFactory());
-    termBytesRefDisplay = getInstance(config.getProperty(TERM_BYTESREF_DISPLAY),
-        StringBytesRefDisplay.INSTANCE);
-    payloadBytesRefDisplay = getInstance(config.getProperty(PAYLOAD_BYTESREF_DISPLAY),
-        RawBytesRefDisplay.INSTANCE);
-    
-    System.out.println("Analyzer: \t\t" + analyzerQuery.getClass());
-    System.out.println("Query Builder: \t\t" + queryBuilder.getClass());
-    System.out.println("Directory Builder: \t" + dirBuilder.getClass());
-    System.out.println("IndexReader Factory: \t" + indexReaderFactory.getClass());
-    System.out.println("Term Bytesref Display: \t" + termBytesRefDisplay.getClass());
-    System.out.println("Payload Bytesref Display: \t" + payloadBytesRefDisplay.getClass());
   }
 
   public Analyzer getAnalyzerQuery() {

--- a/src/main/java/com/senseidb/clue/api/BytesRefPrinter.java
+++ b/src/main/java/com/senseidb/clue/api/BytesRefPrinter.java
@@ -2,8 +2,7 @@ package com.senseidb.clue.api;
 
 import org.apache.lucene.util.BytesRef;
 
-public interface BytesRefPrinter {
-  String print(BytesRef bytesRef);
+public interface BytesRefPrinter {  
   
   public static BytesRefPrinter UTFPrinter = new BytesRefPrinter() {
 
@@ -22,4 +21,7 @@ public interface BytesRefPrinter {
     }
     
   };
+  
+  String print(BytesRef bytesRef);
+  
 }

--- a/src/main/java/com/senseidb/clue/api/RawBytesRefDisplay.java
+++ b/src/main/java/com/senseidb/clue/api/RawBytesRefDisplay.java
@@ -2,6 +2,8 @@ package com.senseidb.clue.api;
 
 public class RawBytesRefDisplay extends BytesRefDisplay {
 
+  public static RawBytesRefDisplay INSTANCE = new RawBytesRefDisplay();
+    
   private RawBytesRefDisplay() {
     
   }
@@ -11,5 +13,4 @@ public class RawBytesRefDisplay extends BytesRefDisplay {
     return BytesRefPrinter.RawBytesPrinter;
   }
 
-  public static RawBytesRefDisplay INSTANCE = new RawBytesRefDisplay();
 }

--- a/src/main/java/com/senseidb/clue/api/StringBytesRefDisplay.java
+++ b/src/main/java/com/senseidb/clue/api/StringBytesRefDisplay.java
@@ -2,6 +2,8 @@ package com.senseidb.clue.api;
 
 public class StringBytesRefDisplay extends BytesRefDisplay {
 
+  public static StringBytesRefDisplay INSTANCE = new StringBytesRefDisplay();
+    
   private StringBytesRefDisplay() {
     
   }
@@ -10,7 +12,5 @@ public class StringBytesRefDisplay extends BytesRefDisplay {
   public BytesRefPrinter getBytesRefPrinter(String field) {
     return BytesRefPrinter.UTFPrinter;
   }
-  
-  public static StringBytesRefDisplay INSTANCE = new StringBytesRefDisplay();
 
 }

--- a/src/main/java/com/senseidb/clue/commands/DocSetInfoCommand.java
+++ b/src/main/java/com/senseidb/clue/commands/DocSetInfoCommand.java
@@ -18,6 +18,11 @@ import com.senseidb.clue.ClueContext;
 public class DocSetInfoCommand extends ClueCommand {
 
   private static final int DEFAULT_BUCKET_SIZE = 1000;
+  
+  private static double[] PERCENTILES = new double[] {
+      50.0, 75.0, 90.0, 95.0, 99.0
+    };
+  
   public DocSetInfoCommand(ClueContext ctx) {
     super(ctx);
   }
@@ -31,10 +36,6 @@ public class DocSetInfoCommand extends ClueCommand {
   public String help() {
     return "doc id set info and stats";
   }
-  
-  private static double[] PERCENTILES = new double[] {
-    50.0, 75.0, 90.0, 95.0, 99.0
-  };
 
   @Override
   public void execute(String[] args, PrintStream out) throws Exception {

--- a/src/main/java/com/senseidb/clue/util/CustomBufferedIndexInput.java
+++ b/src/main/java/com/senseidb/clue/util/CustomBufferedIndexInput.java
@@ -39,12 +39,6 @@ public abstract class CustomBufferedIndexInput extends IndexInput {
   private int bufferLength = 0; // end of valid bytes
   private int bufferPosition = 0; // next byte to read  
   
-  @Override
-  public byte readByte() throws IOException {
-    if (bufferPosition >= bufferLength) refill();
-    return buffer[bufferPosition++];
-  }
-  
   public CustomBufferedIndexInput(String resourceDesc) {
     this(resourceDesc, BUFFER_SIZE);
   }
@@ -53,6 +47,12 @@ public abstract class CustomBufferedIndexInput extends IndexInput {
     super(resourceDesc);
     checkBufferSize(bufferSize);
     this.bufferSize = bufferSize;
+  }
+  
+  @Override
+  public byte readByte() throws IOException {
+    if (bufferPosition >= bufferLength) refill();
+    return buffer[bufferPosition++];
   }
   
   private void checkBufferSize(int bufferSize) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed