### PR TITLE
delete command change

### DIFF
--- a/src/main/java/com/senseidb/clue/commands/DeleteCommand.java
+++ b/src/main/java/com/senseidb/clue/commands/DeleteCommand.java
@@ -2,10 +2,7 @@ package com.senseidb.clue.commands;
 
 import java.io.PrintStream;
 
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
 import com.senseidb.clue.ClueContext;
@@ -28,25 +25,21 @@ public class DeleteCommand extends ClueCommand {
   
   @Override
   public void execute(String[] args, PrintStream out) throws Exception {
-    QueryParser qparser = new QueryParser("contents", new StandardAnalyzer());
     Query q = null;
-    if (args.length == 0){
-      q = new MatchAllDocsQuery();
+    StringBuilder buf = new StringBuilder();
+    for (String s : args){
+      buf.append(s).append(" ");
     }
-    else{
-      StringBuilder buf = new StringBuilder();
-      for (String s : args){
-        buf.append(s).append(" ");
-      }
-      String qstring = buf.toString();
-      try{
-        q = qparser.parse(qstring);
-      }
-      catch(Exception e){
-        out.println("cannot parse query: "+e.getMessage());
-        return;
-      }
+    String qstring = buf.toString();
+    try{
+      q = ctx.getQueryBuilder().build(qstring);
     }
+    catch(Exception e){
+      out.println("cannot parse query: "+e.getMessage());
+      return;
+    }
+    
+    out.println("parsed query: "+q);
     
     if (q != null){
       IndexWriter writer = ctx.getIndexWriter();


### PR DESCRIPTION
-now using configurated query builder
-not using MatchAllDocsQuery when args is empty

I founded (hard way) that query parsing is not the same for `search` and `delete` command when using ***clue.conf*** `query.builder=my.custom.QueryBuilder`.

I removed using `MatchAllDocsQuery` when there are no arguments for `delete` command because _accidental_ deletion of everything is more likely to happen.