### PR TITLE
added count command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Command list:
 	Query Builder: 		class io.dashbase.clue.api.DefaultQueryBuilder
 	Directory Builder: 	class io.dashbase.clue.api.DefaultDirectoryBuilder
 	IndexReader Factory: 	class io.dashbase.clue.api.DefaultIndexReaderFactory
+	count - shows how many documents in index match the given query
 	delete - deletes a list of documents from searching via a query, input: query
 	directory - prints directory information
 	docsetinfo - doc id set info and stats

--- a/pom.xml
+++ b/pom.xml
@@ -169,11 +169,6 @@
             <version>${lucene.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-backward-codecs</artifactId>
-            <version>${lucene.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>

--- a/src/main/java/io/dashbase/clue/LuceneContext.java
+++ b/src/main/java/io/dashbase/clue/LuceneContext.java
@@ -4,6 +4,7 @@ import io.dashbase.clue.api.*;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.*;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 
 import java.io.IOException;
@@ -41,6 +42,10 @@ public class LuceneContext extends ClueContext {
         return readerFactory.getIndexReader();
     }
 
+    public IndexSearcher getIndexSearcher() {
+        return new IndexSearcher(getIndexReader());
+    }
+
     public IndexWriter getIndexWriter(){
         if (registry.isReadonly()) return null;
         if (writer == null) {
@@ -54,7 +59,7 @@ public class LuceneContext extends ClueContext {
     }
 
     Collection<String> fieldNames() {
-        LinkedList<String> fieldNames = new LinkedList<String>();
+        LinkedList<String> fieldNames = new LinkedList<>();
         for (LeafReaderContext context : getIndexReader().leaves()) {
             LeafReader reader = context.reader();
             for(FieldInfo info : reader.getFieldInfos()) {

--- a/src/main/java/io/dashbase/clue/commands/CountCommand.java
+++ b/src/main/java/io/dashbase/clue/commands/CountCommand.java
@@ -1,0 +1,62 @@
+package io.dashbase.clue.commands;
+
+import java.io.PrintStream;
+import java.util.List;
+
+import io.dashbase.clue.LuceneContext;
+import io.dashbase.clue.client.CmdlineHelper;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+
+@Readonly
+public class CountCommand extends ClueCommand {
+
+	private final LuceneContext ctx;
+
+	public CountCommand(LuceneContext ctx) {
+		super(ctx);
+		this.ctx = ctx;
+	}
+
+	@Override
+	public String getName() {
+		return "count";
+	}
+
+	@Override
+	public String help() {
+		return "shows how many documents in index match the given query";
+	}
+
+	@Override
+	protected ArgumentParser buildParser(ArgumentParser parser) {
+		parser.addArgument("-q", "--query").nargs("*").setDefault(new String[]{"*"});
+		return parser;
+	}
+
+	@Override
+	public void execute(Namespace args, PrintStream out) throws Exception {
+		IndexSearcher searcher = ctx.getIndexSearcher();
+
+		List<String> qlist = args.getList("query");
+		Query q;
+		try{
+			q = CmdlineHelper.toQuery(qlist, ctx.getQueryBuilder());
+		}
+		catch(Exception e){
+			out.println("cannot parse query: "+e.getMessage());
+			return;
+		}
+
+		out.println("parsed query: " + q);
+
+		long start = System.currentTimeMillis();
+		int count = searcher.count(q);
+		long end = System.currentTimeMillis();
+
+		out.println("count: " + count);
+		out.println("time: " + (end-start) + "ms");
+	}
+}

--- a/src/main/java/io/dashbase/clue/commands/DefaultCommandRegistrar.java
+++ b/src/main/java/io/dashbase/clue/commands/DefaultCommandRegistrar.java
@@ -12,6 +12,7 @@ public class DefaultCommandRegistrar implements CommandRegistrar {
         new InfoCommand(ctx);
         new DocValCommand(ctx);
         new SearchCommand(ctx);
+        new CountCommand(ctx);
         new TermsCommand(ctx);
         new PostingsCommand(ctx);
         new DocSetInfoCommand(ctx);

--- a/src/main/java/io/dashbase/clue/commands/ExplainCommand.java
+++ b/src/main/java/io/dashbase/clue/commands/ExplainCommand.java
@@ -1,14 +1,11 @@
 package io.dashbase.clue.commands;
 
-import io.dashbase.clue.ClueContext;
 import io.dashbase.clue.LuceneContext;
 import io.dashbase.clue.client.CmdlineHelper;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 
 import java.io.PrintStream;
@@ -44,13 +41,11 @@ public class ExplainCommand extends ClueCommand {
   @Override
   public void execute(Namespace args, PrintStream out) throws Exception {
     List<String> qlist = args.getList("query");
-    String qstring = CmdlineHelper.toString(qlist);
 
     List<Integer> docidList = args.getList("docs");
 
-    IndexReader r = ctx.getIndexReader();
-    IndexSearcher searcher = new IndexSearcher(r);
-    Query q = null;
+    IndexSearcher searcher = ctx.getIndexSearcher();
+    Query q;
 
     try{
       q = CmdlineHelper.toQuery(qlist, ctx.getQueryBuilder());

--- a/src/main/java/io/dashbase/clue/commands/SearchCommand.java
+++ b/src/main/java/io/dashbase/clue/commands/SearchCommand.java
@@ -7,14 +7,10 @@ import io.dashbase.clue.LuceneContext;
 import io.dashbase.clue.client.CmdlineHelper;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-
-import io.dashbase.clue.ClueContext;
 
 @Readonly
 public class SearchCommand extends ClueCommand {
@@ -45,12 +41,10 @@ public class SearchCommand extends ClueCommand {
 
   @Override
   public void execute(Namespace args, PrintStream out) throws Exception {
-    IndexReader r = ctx.getIndexReader();
-    IndexSearcher searcher = new IndexSearcher(r);
+    IndexSearcher searcher = ctx.getIndexSearcher();
     List<String> qlist = args.getList("query");
-    String qstring = CmdlineHelper.toString(qlist);
 
-    Query q = null;
+    Query q;
 
     try{
       q = CmdlineHelper.toQuery(qlist, ctx.getQueryBuilder());
@@ -63,7 +57,7 @@ public class SearchCommand extends ClueCommand {
     out.println("parsed query: " + q);
 
     int count = args.getInt("num");
-    
+
     long start = System.currentTimeMillis();
     TopDocs td = searcher.search(q, count);
     long end = System.currentTimeMillis();


### PR DESCRIPTION
A CLue is an awesome tool, but I find situations, where I don't need concrete results, but total count. Search command returns lower bound of the total count, so I add a distinct command to find count by the query.