### PR TITLE
Bump lucene version to 8.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.dashbase.clue.ClueApplication</mainClass>
-        <lucene.version>8.5.0</lucene.version>
+        <lucene.version>8.8.2</lucene.version>
         <dropwizard.version>1.3.5</dropwizard.version>
         <retrofit2.version>2.5.0</retrofit2.version>
     </properties>


### PR DESCRIPTION
Bumps Lucene version to be able to read version 10 indexes.

```
Exception in thread "main" org.apache.lucene.index.IndexFormatTooNewException: Format version is not supported (resource BufferedChecksumIndexInput(MMapIndexInput(path="/Users/ahornace/opengrok_data/index/test/segments_3"))): 10 (needs to be between 7 and 9)
	at org.apache.lucene.codecs.CodecUtil.checkHeaderNoMagic(CodecUtil.java:216)
	at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:305)
	at org.apache.lucene.index.SegmentInfos.readCommit(SegmentInfos.java:289)
	at org.apache.lucene.index.StandardDirectoryReader$1.doBody(StandardDirectoryReader.java:64)
	at org.apache.lucene.index.StandardDirectoryReader$1.doBody(StandardDirectoryReader.java:61)
	at org.apache.lucene.index.SegmentInfos$FindSegmentsFile.run(SegmentInfos.java:680)
	at org.apache.lucene.index.StandardDirectoryReader.open(StandardDirectoryReader.java:84)
	at org.apache.lucene.index.DirectoryReader.open(DirectoryReader.java:76)
	at org.apache.lucene.index.DirectoryReader.open(DirectoryReader.java:64)
	at io.dashbase.clue.api.DefaultIndexReaderFactory.refreshReader(DefaultIndexReaderFactory.java:27)
	at io.dashbase.clue.api.DefaultIndexReaderFactory.initialize(DefaultIndexReaderFactory.java:19)
	at io.dashbase.clue.LuceneContext.<init>(LuceneContext.java:31)
	at io.dashbase.clue.ClueApplication.newContext(ClueApplication.java:46)
	at io.dashbase.clue.ClueApplication.<init>(ClueApplication.java:50)
	at io.dashbase.clue.ClueApplication.main(ClueApplication.java:155)
```

I just tried to execute the `info` and `terms` commands which worked fine.

Thanks!