### PR TITLE
allow searching with wild(*) prefix

### DIFF
--- a/src/main/java/io/dashbase/clue/api/DefaultQueryBuilder.java
+++ b/src/main/java/io/dashbase/clue/api/DefaultQueryBuilder.java
@@ -3,6 +3,7 @@ package io.dashbase.clue.api;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.Query;
+import io.dashbase.clue.api.NewQueryParser;
 
 public class DefaultQueryBuilder implements QueryBuilder {
 
@@ -11,7 +12,7 @@ public class DefaultQueryBuilder implements QueryBuilder {
   @Override
   public void initialize(String defaultField, Analyzer analyzer)
       throws Exception {
-    parser = new QueryParser(defaultField, analyzer);
+    parser = new NewQueryParser(defaultField, analyzer);
     
   }
 

--- a/src/main/java/io/dashbase/clue/api/NewQueryParser.java
+++ b/src/main/java/io/dashbase/clue/api/NewQueryParser.java
@@ -1,0 +1,12 @@
+package io.dashbase.clue.api;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queryparser.classic.QueryParser;
+
+public class NewQueryParser extends QueryParser {
+
+        public NewQueryParser(String defaultField, Analyzer analyzer) {
+	    super(defaultField, analyzer);
+	    setAllowLeadingWildcard(true);
+	}
+}


### PR DESCRIPTION
By default Lucene doesn't allow search with a wild card as prefix. For example:

`search field:foo*` works but `search field:*bar` would not work by default. 

We need to [setAllowLeadingWildcard](https://lucene.apache.org/core/3_0_3/api/all/org/apache/lucene/queryParser/QueryParser.html#setAllowLeadingWildcard%28boolean%29) for that to work. 